### PR TITLE
feat: added cli install commands for examples

### DIFF
--- a/src/components/AlgokitExampleCard.astro
+++ b/src/components/AlgokitExampleCard.astro
@@ -7,7 +7,6 @@ interface Props {
 
 const { example } = Astro.props;
 const { id, title, description, type } = example;
-console.log(type);
 const cardType = type.replace(/-/g, " ");
 ---
 

--- a/src/components/CopyCodeBlock.astro
+++ b/src/components/CopyCodeBlock.astro
@@ -1,0 +1,76 @@
+---
+interface Props {
+  title: string;
+  code: string;
+}
+
+const { title, code } = Astro.props;
+
+const uniqueId = `copy-btn-${btoa(code).replace(/[+/=]/g, "").slice(0, 24)}`;
+---
+
+<div
+  class="bg-base-100 rounded-lg border border-base-300 overflow-hidden shadow-sm"
+>
+  <div
+    class="flex justify-between items-center px-3 py-2 bg-base-200 border-b border-base-300"
+  >
+    <span class="text-xs text-base-content font-medium">{title}</span>
+    <button id={uniqueId} class="btn btn-xs btn-ghost text-xs" data-code={code}>
+      <span class="copy-text">Copy</span>
+      <span class="copied-text hidden">Copied!</span>
+    </button>
+  </div>
+  <pre
+    class="px-3 py-4 text-base font-mono bg-base-100 overflow-x-auto flex items-center">
+    <code>{code}</code>
+  </pre>
+</div>
+
+<script is:inline define:vars={{ uniqueId }}>
+  document.addEventListener("DOMContentLoaded", function () {
+    const copyButton = document.getElementById(uniqueId);
+
+    if (copyButton) {
+      copyButton.addEventListener("click", async function (event) {
+        const target = event.currentTarget;
+        const code = target.getAttribute("data-code");
+        const copyText = target.querySelector(".copy-text");
+        const copiedText = target.querySelector(".copied-text");
+
+        if (!code || !copyText || !copiedText) return;
+
+        try {
+          await navigator.clipboard.writeText(code);
+
+          // Show "Copied!" feedback
+          copyText.classList.add("hidden");
+          copiedText.classList.remove("hidden");
+
+          // Reset back to "Copy" after 2 seconds
+          setTimeout(() => {
+            copyText.classList.remove("hidden");
+            copiedText.classList.add("hidden");
+          }, 2000);
+        } catch (err) {
+          console.error("Failed to copy code: ", err);
+          // Fallback for older browsers
+          const textArea = document.createElement("textarea");
+          textArea.value = code;
+          document.body.appendChild(textArea);
+          textArea.select();
+          document.execCommand("copy");
+          document.body.removeChild(textArea);
+
+          // Show feedback even for fallback
+          copyText.classList.add("hidden");
+          copiedText.classList.remove("hidden");
+          setTimeout(() => {
+            copyText.classList.remove("hidden");
+            copiedText.classList.add("hidden");
+          }, 2000);
+        }
+      });
+    }
+  });
+</script>

--- a/src/components/detail-page/ExampleHeader.astro
+++ b/src/components/detail-page/ExampleHeader.astro
@@ -24,25 +24,27 @@ const repositoryUrl = `https://github.com/algorandfoundation/algokit-templates/t
   <h1 class="text-2xl md:text-4xl font-bold">{title}</h1>
   <DemoLinks id={id} type={type} />
 </div>
-<div class="flex items-center gap-2">
-  <p class="text-sm">Creator {author}</p>
+<div class="flex flex-col gap-2 pt-2">
+  <div class="flex items-center gap-2">
+    <p class="text-sm">Creator {author}</p>
+    {
+      repositoryUrl && (
+        <a href={repositoryUrl} target="_blank" class="github-link">
+          <div class="flex items-center gap-1">
+            <Icon name="mdi:github" />
+            <span class="text-sm link">Source</span>
+          </div>
+        </a>
+      )
+    }
+  </div>
   {
-    repositoryUrl && (
-      <a href={repositoryUrl} target="_blank" class="github-link">
-        <div class="flex items-center gap-1">
-          <Icon name="mdi:github" />
-          <span class="text-sm link">Source</span>
-        </div>
-      </a>
+    tags && (
+      <div class="flex flex-wrap gap-2">
+        {tags.map((tag) => (
+          <Tag tag={tag} />
+        ))}
+      </div>
     )
   }
 </div>
-{
-  tags && (
-    <div class="flex flex-wrap gap-2">
-      {tags.map((tag) => (
-        <Tag tag={tag} />
-      ))}
-    </div>
-  )
-}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,12 +10,15 @@ import "../styles/global.css";
     <link rel="icon" type="image/png" href="/algo-favicon.png" />
     <meta name="generator" content={Astro.generator} />
     <title>Algokit Examples Gallery</title>
-    
+
     <!-- Add this script before any content renders -->
     <script is:inline>
       const savedTheme = localStorage.getItem("theme");
-      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-      const theme = savedTheme || (prefersDark ? "algorand-dark" : "algorand-light");
+      const prefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
+      const theme =
+        savedTheme || (prefersDark ? "algorand-dark" : "algorand-light");
       document.documentElement.setAttribute("data-theme", theme);
     </script>
     <link
@@ -41,58 +44,102 @@ import "../styles/global.css";
     />
   </head>
   <body>
-    <div
-      class="navbar bg-base-100 shadow-sm fixed top-0 left-0 right-0 z-50 h-[75px] px-3 md:px-8"
-    >
-      <div class="flex-1 flex items-center gap-2 h-full">
-        <div class="h-full">
-          <img
-            src="/images/algokit-logo-color-RGB.svg"
-            alt="AlgoKit Logo"
-            class="h-full w-full object-contain block dark:hidden"
-          />
-          <img
-            src="/images/algokit-logo-white-teal-RGB.svg"
-            alt="AlgoKit Logo"
-            class="h-full w-full object-contain hidden dark:block"
-          />
+    <html lang="en" data-theme="algorand-light">
+      <body>
+        <div class="flex flex-col h-screen">
+          <div
+            class="navbar bg-base-100 shadow-sm left-0 right-0 z-50 h-[75px] px-3 md:px-8"
+          >
+            <div class="flex-1 flex items-center gap-2 h-full">
+              <div class="h-full">
+                <img
+                  src="/images/algokit-logo-color-RGB.svg"
+                  alt="AlgoKit Logo"
+                  class="h-full w-full object-contain block dark:hidden"
+                />
+                <img
+                  src="/images/algokit-logo-white-teal-RGB.svg"
+                  alt="AlgoKit Logo"
+                  class="h-full w-full object-contain hidden dark:block"
+                />
+              </div>
+              <span class="text-3xl font-bold text-primary">Gallery</span>
+            </div>
+            <div class="flex-none">
+              <label class="swap swap-rotate">
+                <!-- this hidden checkbox controls the state -->
+                <input
+                  type="checkbox"
+                  class="theme-controller"
+                  value="algorand-dark"
+                />
+
+                <!-- sun icon -->
+                <svg
+                  class="swap-off h-8 w-8 fill-primary"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M5.64,17l-.71.71a1,1,0,0,0,0,1.41,1,1,0,0,0,1.41,0l.71-.71A1,1,0,0,0,5.64,17ZM5,12a1,1,0,0,0-1-1H3a1,1,0,0,0,0,2H4A1,1,0,0,0,5,12Zm7-7a1,1,0,0,0,1-1V3a1,1,0,0,0-2,0V4A1,1,0,0,0,12,5ZM5.64,7.05a1,1,0,0,0,.7.29,1,1,0,0,0,.71-.29,1,1,0,0,0,0-1.41l-.71-.71A1,1,0,0,0,4.93,6.34Zm12,.29a1,1,0,0,0,.7-.29l.71-.71a1,1,0,1,0-1.41-1.41L17,5.64a1,1,0,0,0,0,1.41A1,1,0,0,0,17.66,7.34ZM21,11H20a1,1,0,0,0,0,2h1a1,1,0,0,0,0-2Zm-9,8a1,1,0,0,0-1,1v1a1,1,0,0,0,2,0V20A1,1,0,0,0,12,19ZM18.36,17A1,1,0,0,0,17,18.36l.71.71a1,1,0,0,0,1.41,0,1,1,0,0,0,0-1.41ZM12,6.5A5.5,5.5,0,1,0,17.5,12,5.51,5.51,0,0,0,12,6.5Zm0,9A3.5,3.5,0,1,1,15.5,12,3.5,3.5,0,0,1,12,15.5Z"
+                  ></path>
+                </svg>
+
+                <!-- moon icon -->
+                <svg
+                  class="swap-on h-8 w-8 fill-primary"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M21.64,13a1,1,0,0,0-1.05-.14,8.05,8.05,0,0,1-3.37.73A8.15,8.15,0,0,1,9.08,5.49a8.59,8.59,0,0,1,.25-2A1,1,0,0,0,8,2.36,10.14,10.14,0,1,0,22,14.05,1,1,0,0,0,21.64,13Zm-9.5,6.69A8.14,8.14,0,0,1,7.08,5.22v.27A10.15,10.15,0,0,0,17.22,15.63a9.79,9.79,0,0,0,2.1-.22A8.11,8.11,0,0,1,12.14,19.73Z"
+                  ></path>
+                </svg>
+              </label>
+            </div>
+          </div>
+          <div class="flex-1 min-h-0 overflow-y-auto">
+            <slot />
+          </div>
         </div>
-        <span class="text-3xl font-bold text-primary">Gallery</span>
-      </div>
-      <div class="flex-none">
-        <label class="swap swap-rotate">
-          <!-- this hidden checkbox controls the state -->
-          <input
-            type="checkbox"
-            class="theme-controller"
-            value="algorand-dark"
-          />
+      </body>
+    </html>
 
-          <!-- sun icon -->
-          <svg
-            class="swap-off h-8 w-8 fill-primary"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M5.64,17l-.71.71a1,1,0,0,0,0,1.41,1,1,0,0,0,1.41,0l.71-.71A1,1,0,0,0,5.64,17ZM5,12a1,1,0,0,0-1-1H3a1,1,0,0,0,0,2H4A1,1,0,0,0,5,12Zm7-7a1,1,0,0,0,1-1V3a1,1,0,0,0-2,0V4A1,1,0,0,0,12,5ZM5.64,7.05a1,1,0,0,0,.7.29,1,1,0,0,0,.71-.29,1,1,0,0,0,0-1.41l-.71-.71A1,1,0,0,0,4.93,6.34Zm12,.29a1,1,0,0,0,.7-.29l.71-.71a1,1,0,1,0-1.41-1.41L17,5.64a1,1,0,0,0,0,1.41A1,1,0,0,0,17.66,7.34ZM21,11H20a1,1,0,0,0,0,2h1a1,1,0,0,0,0-2Zm-9,8a1,1,0,0,0-1,1v1a1,1,0,0,0,2,0V20A1,1,0,0,0,12,19ZM18.36,17A1,1,0,0,0,17,18.36l.71.71a1,1,0,0,0,1.41,0,1,1,0,0,0,0-1.41ZM12,6.5A5.5,5.5,0,1,0,17.5,12,5.51,5.51,0,0,0,12,6.5Zm0,9A3.5,3.5,0,1,1,15.5,12,3.5,3.5,0,0,1,12,15.5Z"
-            ></path>
-          </svg>
+    <script>
+      // Function to set theme and update checkbox
+      function setTheme(theme: string, checkbox: HTMLInputElement) {
+        document.documentElement.setAttribute("data-theme", theme);
+        checkbox.checked = theme === "algorand-dark";
+        localStorage.setItem("theme", theme);
+      }
 
-          <!-- moon icon -->
-          <svg
-            class="swap-on h-8 w-8 fill-primary"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M21.64,13a1,1,0,0,0-1.05-.14,8.05,8.05,0,0,1-3.37.73A8.15,8.15,0,0,1,9.08,5.49a8.59,8.59,0,0,1,.25-2A1,1,0,0,0,8,2.36,10.14,10.14,0,1,0,22,14.05,1,1,0,0,0,21.64,13Zm-9.5,6.69A8.14,8.14,0,0,1,7.08,5.22v.27A10.15,10.15,0,0,0,17.22,15.63a9.79,9.79,0,0,0,2.1-.22A8.11,8.11,0,0,1,12.14,19.73Z"
-            ></path>
-          </svg>
-        </label>
-      </div>
-    </div>
-    <slot />
+      // Initialize theme handling
+      document.addEventListener("DOMContentLoaded", () => {
+        const checkbox = document.querySelector(
+          ".theme-controller"
+        ) as HTMLInputElement;
+        if (!checkbox) return;
+
+        // Get saved theme or use system preference
+        const savedTheme = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia(
+          "(prefers-color-scheme: dark)"
+        ).matches;
+        const initialTheme =
+          savedTheme || (prefersDark ? "algorand-dark" : "algorand-light");
+
+        // Set initial theme
+        setTheme(initialTheme, checkbox);
+
+        // Handle theme changes
+        checkbox.addEventListener("change", () => {
+          const newTheme = checkbox.checked
+            ? "algorand-dark"
+            : "algorand-light";
+          setTheme(newTheme, checkbox);
+        });
+      });
+    </script>
   </body>
 </html>
 
@@ -129,12 +176,3 @@ import "../styles/global.css";
     });
   });
 </script>
-
-<style>
-  html,
-  body {
-    margin: 0;
-    width: 100%;
-    height: 100%;
-  }
-</style>

--- a/src/pages/[id].astro
+++ b/src/pages/[id].astro
@@ -3,6 +3,7 @@ import Layout from "../layouts/Layout.astro";
 import { Icon } from "astro-icon/components";
 import DescriptionPanel from "@/components/detail-page/DescriptionPanel.astro";
 import ExampleHeader from "@/components/detail-page/ExampleHeader.astro";
+import CopyCodeBlock from "@/components/CopyCodeBlock.astro";
 import path from "node:path";
 import { yamlToObject } from "../utils/yaml";
 import type { Examples } from "@/types/example";
@@ -31,19 +32,11 @@ const {
   type,
   detailsPages,
 } = example;
-
-// Add dynamic import using the title
 ---
 
 <Layout title={title}>
-  <main class="container px-4 mx-auto flex flex-col pt-[64px]">
-    <div
-      class="flex flex-col gap-2 mb-5 sticky top-0 bg-base-100 pt-6 pb-3 z-10"
-    >
-      <div class="flex items-center gap-2 mb-4">
-        <Icon name="mdi:arrow-left" />
-        <a href="/" class="link text-sm">Back to templates</a>
-      </div>
+  <main class="container px-4 mx-auto flex flex-col">
+    <div class="sticky top-0 bg-base-100 z-10 py-2">
       <ExampleHeader
         title={title}
         id={id}
@@ -53,13 +46,20 @@ const {
         tags={tags}
       />
     </div>
-    <DescriptionPanel
-      description={description}
-      features={features}
-      title={title}
-      type={type}
-    />
-    <div class="divider"></div>
+    <!-- <div class="divider my-1"></div> -->
+    <div class="flex flex-col gap-4 pt-2">
+      <CopyCodeBlock
+        title="Install with AlgoKit CLI"
+        code={`algokit init example ${id}`}
+      />
+      <DescriptionPanel
+        description={description}
+        features={features}
+        title={title}
+        type={type}
+      />
+    </div>
+    <div class="divider my-2"></div>
     <DetailsPages id={id} detailsPages={detailsPages} />
   </main>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ const { examples } = await yamlToObject<Examples>(yamlFilePath);
 ---
 
 <Layout title="Example Gallery">
-  <main class="pt-[64px]">
+  <main>
     <div class="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-8 p-8">
       {examples.map((example) => <AlgokitExampleCard example={example} />)}
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -137,3 +137,11 @@
   font-style: normal;
   font-display: swap;
 }
+
+
+/* html,
+body {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+} */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -137,11 +137,3 @@
   font-style: normal;
   font-display: swap;
 }
-
-
-/* html,
-body {
-  margin: 0;
-  width: 100%;
-  height: 100%;
-} */


### PR DESCRIPTION

Added a copy code block component so people can copy the `algokit init example` command locally instead of having to open the codespace. Also fixed some layout issues.

Changes:
- New CopyCodeBlock component with copy to clipboard functionality
- Removed unused console.log 
- Fixed the navbar/layout - was using fixed positioning. Now it's using flex
- Put the install command at the top of example pages since that's probably what people want first
- Moved tags below author info, looks better
- Removed the back button since it was kinda redundant
- Fixed theme switching, it was getting out of sync sometimes
- Updated submodule
- Cleaned up some CSS

<img width="1499" alt="image" src="https://github.com/user-attachments/assets/aa3b88ad-ce8a-40cd-97cb-6386f6fafb7e" />
